### PR TITLE
Fix word break with regex

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -46,6 +46,16 @@ const HeartIcon = ({
   );
 };
 
+function split(str) {
+  // https://github.com/nota/split-graphemes/blob/master/src/thai.js
+  const letter = '[\\u0E00-\\u0E7F]';
+  const trailingLetter = '[\\u0E31\\u0E33-\\u0E3A\\u0E47-\\u0E4E]';
+  const thai = `${letter}${trailingLetter}*`;
+  const splitter = new RegExp(`(${thai}|.)`, 'gui');
+
+  return str.replace(/ำ/g, 'ํา').replace(/แ/g, 'เเ').match(splitter) || [];
+};
+
 export default function Home() {
 
 
@@ -68,7 +78,6 @@ export default function Home() {
 
   const closeLight = useCallback(() => toggleLight(false), []);
   useClickOutside(popoverLight, closeLight);
-
 
   const handleTextChange = (e) => {
     setText(e.target.value);
@@ -276,18 +285,20 @@ export default function Home() {
         <div ref={imageRef} className="image-container" id="image-container">
           <img src="/rama8-img.png" height="100%" width="100%" />
 
-
-          <div className="overlay neonText"
+          <div
+            className="overlay neonText"
             style={{
               transform: `translate(${xAxis}px , ${yAxis}px)`,
               textShadow: `0 0 5px ${colorLight}, 0 0 15px ${colorLight}, 0 0 20px ${colorLight}, 0 0 40px ${colorLight}, 0 0 60px ${colorLight}, 0 0 10px ${colorLight}, 0 0 98px ${colorLight}`,
               color: color,
-              fontSize: fontSize
-            }}>
-            {text}
+              fontSize: fontSize,
+              textAlign: "center",
+            }}
+          >
+            {split(text).map((s, idx) => {
+              return <div key={idx}>{s}</div>
+            })}
           </div>
-
-
         </div>
       </Grid>
       {/* {xAxis}


### PR DESCRIPTION
This PR fixes weird Thai word breaking

Reproduce with `ก้าวไกล&สระอำ`

Before: 
<img width="99" alt="image" src="https://github.com/jaytnw/rama8/assets/248741/8688201e-ae61-45e7-9b0d-855c4483b164">

After fix:
<img width="127" alt="image" src="https://github.com/jaytnw/rama8/assets/248741/63271582-72af-4ff5-8fd8-5e4d6d41b2fd">

Downloaded file does not have any problem
![adsRama8 (6)](https://github.com/jaytnw/rama8/assets/248741/4d05fcf4-3a43-4590-a876-cd9e4ea3c0dc)



