### PR TITLE
Use initialValue instead of value to prevent flickering

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -137,7 +137,7 @@ export default function Home() {
           <Grid.Container>
             <Input
               type="text"
-              value={text}
+              initialValue={text}
               underlined
               clearable
               onChange={handleTextChange}


### PR DESCRIPTION

https://github.com/jaytnw/rama8/assets/248741/789da4a5-3b57-47ed-bcd5-acf7a94c2da8

Fix cursor moved to end of string when typing